### PR TITLE
Allow specifying login url as a function (dynamic redirect)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,14 +49,14 @@ Options
 -------
 
 `SESSION_AUTO_LOAD` -- Load session every request automatically
-                       Session will be loaded into `request.session`.
+Session will be loaded into `request.session`.
 
 `SESSION_DEFAULT_USER_CHECKER` -- A function which checks logged user (lambda x: x)
 
 `SESSION_LOGIN_URL` -- Redirect URL ('/login'), or it may be a function
 which accepts `request` object and returns a string.
 
-`SESSION_SECRET`    -- A secret code ('Insecuresecret')
+`SESSION_SECRET` -- A secret code ('Insecuresecret')
 
 Examples
 --------

--- a/README.rst
+++ b/README.rst
@@ -53,7 +53,8 @@ Options
 
 `SESSION_DEFAULT_USER_CHECKER` -- A function which checks logged user (lambda x: x)
 
-`SESSION_LOGIN_URL` -- Redirect URL ('/login')
+`SESSION_LOGIN_URL` -- Redirect URL ('/login'), or it may be a function
+which accepts `request` object and returns a string.
 
 `SESSION_SECRET`    -- A secret code ('Insecuresecret')
 

--- a/muffin_session.py
+++ b/muffin_session.py
@@ -19,8 +19,6 @@ __author__ = "Kirill Klenov <horneds@gmail.com>"
 __license__ = "MIT"
 
 
-FUNC = lambda x: x # noqa
-
 SESSION_KEY = 'session'
 USER_KEY = 'user'
 
@@ -103,7 +101,7 @@ class Plugin(BasePlugin):
         return request[USER_KEY]
 
     @asyncio.coroutine
-    def check_user(self, request, func=FUNC, location=None, **kwargs):
+    def check_user(self, request, func=None, location=None, **kwargs):
         """
         Check for user is logged and pass the given func.
         :param func: user checker function, defaults to default_user_checker

--- a/muffin_session.py
+++ b/muffin_session.py
@@ -110,6 +110,8 @@ class Plugin(BasePlugin):
         if not func(user):
             while callable(location):
                 location = location(request)
+                while asyncio.iscoroutine(location):
+                    location = yield from location
             raise HTTPFound(location or self.cfg.login_url, **kwargs)
         return user
 

--- a/muffin_session.py
+++ b/muffin_session.py
@@ -108,6 +108,8 @@ class Plugin(BasePlugin):
         user = yield from self.load_user(request)
         func = func or self.cfg.default_user_checker
         if not func(user):
+            while callable(location):
+                location = location(request)
             raise HTTPFound(location or self.cfg.login_url, **kwargs)
         return user
 

--- a/muffin_session.py
+++ b/muffin_session.py
@@ -112,11 +112,12 @@ class Plugin(BasePlugin):
         user = yield from self.load_user(request)
         func = func or self.cfg.default_user_checker
         if not func(user):
+            location = location or self.cfg.login_url
             while callable(location):
                 location = location(request)
                 while asyncio.iscoroutine(location):
                     location = yield from location
-            raise HTTPFound(location or self.cfg.login_url, **kwargs)
+            raise HTTPFound(location, **kwargs)
         return user
 
     def user_pass(self, func=None, location=None, **rkwargs):

--- a/muffin_session.py
+++ b/muffin_session.py
@@ -104,7 +104,13 @@ class Plugin(BasePlugin):
 
     @asyncio.coroutine
     def check_user(self, request, func=FUNC, location=None, **kwargs):
-        """Check for user is logged and pass the given func."""
+        """
+        Check for user is logged and pass the given func.
+        :param func: user checker function, defaults to default_user_checker
+        :param location: where to redirect if user is not logged in.
+        May be either string (URL) or function
+        which accepts request as argument and returns string URL.
+        """
         user = yield from self.load_user(request)
         func = func or self.cfg.default_user_checker
         if not func(user):

--- a/tests.py
+++ b/tests.py
@@ -57,23 +57,6 @@ def app(loop):
 
     return app
 
-@pytest.fixture(scope='session')
-def app_dyn(loop):
-    app_dyn = muffin.Application(
-        'session_dyn', loop=loop,
-
-        PLUGINS=['muffin_session'],
-        SESSION_LOGIN_URL = lambda req: '/login?return='+req.path,
-    )
-
-    @app_dyn.register('/auth')
-    @app_dyn.ps.session.user_pass()
-    def auth(request):
-        return request.user
-
-    return app_dyn
-
-
 def test_muffin_session(app, client):
     assert app.ps.session
 
@@ -112,9 +95,9 @@ def test_muffin_session(app, client):
     response = client.get('/session')
     assert 'id' not in response.json
 
-def test_muffin_session_dyn(app_dyn, client):
-    assert app_dyn.ps.session
-    assert type(app_dyn.ps.session.cfg.login_url).__name__ == 'function'
+    # FIXME it is a hack, but having two fixtures doesn't work
+    object.__setattr__(app.ps.session.cfg, '_lock', False)
+    app.ps.session.cfg.login_url = lambda request: '/login?redir='+request.path
 
     response = client.get('/auth')
     assert response.status_code == 302

--- a/tests.py
+++ b/tests.py
@@ -1,4 +1,5 @@
 import pytest
+import asyncio
 import muffin
 
 
@@ -20,6 +21,15 @@ def app(loop):
     @app.register('/auth_dyn')
     @app.ps.session.user_pass(location=determine_redir)
     def auth_dyn(request):
+        return request.user
+
+    @asyncio.coroutine
+    def determine_redir_async(request):
+        return request.GET.get('target')
+
+    @app.register('/auth_dyn_async')
+    @app.ps.session.user_pass(location=determine_redir)
+    def auth_dyn_async(request):
         return request.user
 
     @app.register('/login')
@@ -55,6 +65,10 @@ def test_muffin_session(app, client):
     assert response.headers['location'] == '/login'
 
     response = client.get('/auth_dyn', {'target': '/another_page'})
+    assert response.status_code == 302
+    assert response.headers['location'] == '/another_page'
+
+    response = client.get('/auth_dyn_async', {'target': '/another_page'})
     assert response.status_code == 302
     assert response.headers['location'] == '/another_page'
 

--- a/tests.py
+++ b/tests.py
@@ -44,6 +44,7 @@ def test_muffin_session(app, client):
 
     response = client.get('/auth')
     assert response.status_code == 302
+    assert response.headers['location'] == '/login'
 
     client.get('/login', {'name': 'mike'})
     response = client.get('/auth')
@@ -59,9 +60,11 @@ def test_muffin_session(app, client):
     client.get('/logout')
     response = client.get('/auth')
     assert response.status_code == 302
+    assert response.headers['location'] == '/login'
 
     response = client.get('/logout')
     assert response.status_code == 302
+    assert response.headers['location'] == '/'
 
     response = client.get('/session')
     assert 'id' not in response.json


### PR DESCRIPTION
This can be used to make redirect with return URL, like this:

    SESSION_LOGIN_URL = lambda request: '/login?return='+request.path
    
    @app.route('/secure')
    def secure(request):
       return request.user

    @app.route('/login')
    def login(request):
        # ...do a login...
        return HTTPFound(request.GET.get('return', '/'))